### PR TITLE
fix: changes for FFI API in Deno 1.44

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -81,7 +81,9 @@ export async function connect(
     null,
   );
   assertResult(
-    Deno.UnsafePointer.value(hFile) !== C.INVALID_HANDLE_VALUE,
+    !(C.INVALID_HANDLE_VALUE as readonly (number | bigint)[]).includes(
+      Deno.UnsafePointer.value(hFile),
+    ),
     `CreateFile failed: ${path}`,
   );
   return new NamedPipeClientConn(path, hFile);

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,9 @@
-export const INVALID_HANDLE_VALUE = -1n;
+export const INVALID_HANDLE_VALUE = [
+  0xffff_ffff_ffff_ffffn,
+  // NOTE: Prior to Deno 1.44, -1n was returned as the error handle.
+  // See: https://github.com/denoland/deno/pull/23981
+  -1n,
+] as const;
 
 export const ERROR_SUCCESS = 0;
 export const ERROR_BROKEN_PIPE = 109;

--- a/server.ts
+++ b/server.ts
@@ -215,7 +215,9 @@ function createNamedPipe(params: Required<NamedPipeListenOptions>) {
     null,
   );
   assertResult(
-    Deno.UnsafePointer.value(handle) !== C.INVALID_HANDLE_VALUE,
+    !(C.INVALID_HANDLE_VALUE as readonly (number | bigint)[]).includes(
+      Deno.UnsafePointer.value(handle),
+    ),
     `CreateNamedPipe failed: ${path}`,
   );
   return handle;


### PR DESCRIPTION
Prior to Deno 1.44, -1n was returned as the error handle.
See: https://github.com/denoland/deno/pull/23981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Deno 1.44 by updating handle validation logic.
- **Refactor**
  - Updated condition checks for handle validity across the application to use a more robust approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->