### PR TITLE
chore: bump @milly/streams from 1.0.0 to 1.0.1

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,7 +3,7 @@
   "packages": {
     "specifiers": {
       "jsr:@lambdalisue/async@^2.1.1": "jsr:@lambdalisue/async@2.1.1",
-      "jsr:@milly/streams@^1.0.0": "jsr:@milly/streams@1.0.0",
+      "jsr:@milly/streams@^1.0.0": "jsr:@milly/streams@1.0.1",
       "jsr:@nick/dispose@^1.1.0": "jsr:@nick/dispose@1.1.0",
       "jsr:@std/assert@1.0.0-rc.2": "jsr:@std/assert@1.0.0-rc.2",
       "jsr:@std/assert@^1.0.1": "jsr:@std/assert@1.0.1",
@@ -17,8 +17,8 @@
       "@lambdalisue/async@2.1.1": {
         "integrity": "1fc9bc6f4ed50215cd2f7217842b18cea80f81c25744f88f8c5eb4be5a1c9ab4"
       },
-      "@milly/streams@1.0.0": {
-        "integrity": "7d9b4a56d7defa7b4a500ea6b5717480a647633be58efb21b80914e380c1f33e"
+      "@milly/streams@1.0.1": {
+        "integrity": "5115f8bbce4f1db1a4d8e05e3c41fe0413ccd3b0c1727183555033ef79cc878b"
       },
       "@nick/dispose@1.1.0": {
         "integrity": "73a15b90cb48e1435801258ba3ac7a19382823349dedcacbb8e5b5b673ce9d17"


### PR DESCRIPTION
#### :package: @milly/streams [1.0.0](https://jsr.io/@milly/streams/1.0.0) → [1.0.1](https://jsr.io/@milly/streams/1.0.1)